### PR TITLE
proxy 가져오는 로직 _request 로직 외부로 분리

### DIFF
--- a/app/alarm/sender.py
+++ b/app/alarm/sender.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 import aiohttp
 import orjson
+import redis.exceptions
 from aiohttp import BasicAuth, ClientResponse, ClientSession
 
 from app.alarm.constants import DEFAULT_RETRY_AFTER, DEFAULT_RETRY_ATTEMPT, DISCORD_WEBHOOK_URL
@@ -56,6 +57,10 @@ class AlarmSender:
             logger.warning(exc)
         except aiohttp.ClientConnectionError as exc:
             logger.warning(f"클라이언트 커넥션 에러가 발생했습니다, (exception: {exc})")
+        except redis.exceptions.ConnectionError as exc:
+            # TODO: 레디스 커넥션 이슈 해결 시 해당 로직 제거
+            logger.warning(f"레디스 커넥션 에러가 발생했습니다. 서버를 재시작 합니다, (exception: {exc}\n{traceback.format_exc()})")
+            exit(0)
         except Exception as exc:
             logger.warning(f"전송에 실패했습니다, (exception: {exc}\n{traceback.format_exc()})")
         return url

--- a/app/node/manager.py
+++ b/app/node/manager.py
@@ -5,11 +5,12 @@ from datetime import timedelta
 from redis.asyncio import Redis
 
 from app.common.logger import logger
-from app.common.settings import settings
 from app.node.constants import NODE_HEALTH_CHECK_INTERVAL, TASK_POP_INTERVAL
 
 
 class NodeManager:
+    _NODE_TASK_QUEUE = "node_task_queue"
+
     def __init__(self, node_id: str, session: Redis):
         self._node_id = node_id
         self._session = session
@@ -22,7 +23,7 @@ class NodeManager:
 
     async def pop_task(self) -> tuple[str, str] | None:
         try:
-            return await self._session.blpop(settings.NODE_ID, timeout=TASK_POP_INTERVAL)
+            return await self._session.blpop(self._NODE_TASK_QUEUE, timeout=TASK_POP_INTERVAL)
         except (TimeoutError, ConnectionError) as exc:
             logger.warning(f"Redis connection error. (exception: {exc}), {traceback.format_exc()}")
             return None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   node:
-    image: wakscode-node
+    image: wakscord-node
     build: .
     command: python app/main.py
     restart: always


### PR DESCRIPTION
- wnm-api: https://github.com/wakscord/wnm-api/pull/6
- redis session connection 선점으로 session closed 이슈가 발생해 get_proxy 로직 _request 메소드 외부로 분리