### PR TITLE
ci(deploy): build 된 image만 업데이트 하도록 수정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ on:
 env:
   DOCKER_IMAGE: minibox24/wakscord-node:latest
   SERVICE_NAME: wakscord-node
-  CONTAINER_REPLICA_COUNT: 10
 
 jobs:
   build:
@@ -69,4 +68,4 @@ jobs:
           host: ${{ secrets.MANAGER_HOST }}
           username: ${{ secrets.MANAGER_USERNAME }}
           key: ${{ secrets.MANAGER_SSH_KEY }}
-          script: docker service update --replicas ${{ env.CONTAINER_REPLICA_COUNT }} --replicas-max-per-node 1 --image ${{ env.DOCKER_IMAGE }} ${{ env.SERVICE_NAME }}
+          script: docker service update --image ${{ env.DOCKER_IMAGE }} ${{ env.SERVICE_NAME }}


### PR DESCRIPTION
- replicas 지정해 줄 경우 무조건 지정한 replicas 수만큼 태스크를 생성하려고 해서 오류 발생
- 스케일링은 일단 직접 진행 하기로 하고 actions에서 옵션 제외